### PR TITLE
Interval fixes

### DIFF
--- a/core/chords.py
+++ b/core/chords.py
@@ -6,17 +6,18 @@ from core.chromatic import ChromaticScale
 class Intervals(Enum):
     """Standard intervals in western music in number of half-steps"""
     P1 = 0  # perfect unison
-    m2 = 3  # minor second
-    M2 = 4  # major second
+    m2 = 1  # minor second
+    M2 = 2  # major second
     m3 = 3  # minor third
     M3 = 4  # major third
     P4 = 5  # perfect fourth
     TT = 6  # tritone
     d5 = 6  # diminished fifth
     P5 = 7  # perfect fifth
+    A5 = 8  # augmented fifth
     m6 = 8  # minor sixth
     M6 = 9  # major sixth
-    A5 = 8   # augmented 5
+    d7 = 9  # diminished seventh
     m7 = 10  # minor seventh
     M7 = 11  # major seventh
     P8 = 12  # octave
@@ -35,7 +36,7 @@ class ChordFormula(Enum):
     dom7 = Intervals.P1.value, Intervals.M3.value, Intervals.P5.value, Intervals.m7.value
     minor7 = Intervals.P1.value, Intervals.m3.value, Intervals.P5.value, Intervals.m7.value
     minor7_flat5 = Intervals.P1.value, Intervals.m3.value, Intervals.d5.value, Intervals.m7.value
-    dim7 = Intervals.P1.value, Intervals.m3.value, Intervals.d5.value, Intervals.M6.value
+    dim7 = Intervals.P1.value, Intervals.m3.value, Intervals.d5.value, Intervals.d7.value
     major9 = Intervals.P1.value, Intervals.M3.value, Intervals.P5.value, Intervals.M7.value, Intervals.M9.value
     dom9 = Intervals.P1.value, Intervals.M3.value, Intervals.P5.value, Intervals.m7.value, Intervals.M9.value
     


### PR DESCRIPTION
Maj/min seconds had incorrect values, augmented fifth was just moved between P5 and m6 for easier reading, and for technical theory consistency diminished seventh (same interval as major sixth) was added and used for dim7 chord recipe